### PR TITLE
Fix App Extension API only warning in WatchKit

### DIFF
--- a/CloudCore.xcodeproj/project.pbxproj
+++ b/CloudCore.xcodeproj/project.pbxproj
@@ -918,6 +918,7 @@
 		D5B2E8B41C3A780C00C0327D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -943,6 +944,7 @@
 		D5B2E8B51C3A780C00C0327D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Make sure only app extension APIs only are used to prevent warnings being thrown in WatchKit.