### PR TITLE
Added enable(... withPull: Bool) 

### DIFF
--- a/Source/Classes/CloudCore.swift
+++ b/Source/Classes/CloudCore.swift
@@ -83,8 +83,9 @@ open class CloudCore {
 	/// Enable CloudKit and Core Data synchronization
 	///
 	/// - Parameters:
-	///   - container: `NSPersistentContainer` that will be used to save data
-	public static func enable(persistentContainer container: NSPersistentContainer) {
+    ///   - container: `NSPersistentContainer` that will be used to save data
+    ///   - withPull: `Bool` to specify if Pull shoul dbe perfromed or not on enable
+    public static func enable(persistentContainer container: NSPersistentContainer, withPull: Bool) {
 		// Listen for local changes
 		let observer = CoreDataObserver(container: container)
 		observer.delegate = self.delegate
@@ -98,6 +99,10 @@ open class CloudCore {
 		queue.addOperation(subscribeOperation)
 		#endif
 		
+        if !withPull {
+        	return
+        }
+        
 		// Fetch updated data (e.g. push notifications weren't received)
         let updateFromCloudOperation = PullOperation(persistentContainer: container)
 		updateFromCloudOperation.errorBlock = {
@@ -110,6 +115,10 @@ open class CloudCore {
 			
 		queue.addOperation(updateFromCloudOperation)
 	}
+    
+    public static func enable(persistentContainer container: NSPersistentContainer) {
+        self.enable(persistentContainer: container, withPull: true)
+    }
 	
 	/// Disables synchronization (push notifications won't be sent also)
 	public static func disable() {

--- a/Source/Model/CloudCoreConfig.swift
+++ b/Source/Model/CloudCoreConfig.swift
@@ -26,6 +26,8 @@ import CloudKit
 public struct CloudCoreConfig {
 	
 	// MARK: CloudKit
+    
+    public init() {}
 	
     /// The CKContainer to store CoreData. Set this to a custom container to
     /// support sharing data between multiple apps in an App Group (e.g. iOS and macOS).


### PR DESCRIPTION
Added enable(persistentContainer container: NSPersistentContainer, withPull: Bool) to allow developer to specify if Pull should be performed upon enable.

Also, added init() {} to CloudCoreConfig to allow creation of instance.