### PR TITLE
Add semaphore to limit one change being processed at once

### DIFF
--- a/Example/Sources/AppDelegate.swift
+++ b/Example/Sources/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
                                                name: .reachabilityChanged,
                                                object: reachability)
         
-        reachability = Reachability(hostname: "icloud.com")
+        reachability = try! Reachability(hostname: "icloud.com")
         try? reachability?.startNotifier()
         
 		return true
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     @objc private func reachabilityChanged(notification: Notification) {
         let reachability = notification.object as! Reachability
         
-        CloudCore.isOnline = reachability.connection != .none
+        CloudCore.isOnline = reachability.connection != .unavailable
     }
     
 	// Notification from CloudKit about changes in remote database

--- a/Source/Classes/Push/CoreDataObserver.swift
+++ b/Source/Classes/Push/CoreDataObserver.swift
@@ -19,6 +19,8 @@ class CoreDataObserver {
 
 	let cloudContextName = "CloudCoreSync"
 	
+	let semaphore = DispatchSemaphore(value: 1)
+
 	// Used for errors delegation
 	weak var delegate: CloudCoreDelegate?
 	
@@ -82,6 +84,11 @@ class CoreDataObserver {
     }
     
     func processChanges() -> Bool {
+        semaphore.wait()
+        defer {
+            semaphore.signal()
+        }
+
         var success = true
         
         CloudCore.delegate?.willSyncToCloud()


### PR DESCRIPTION
When we create multiple objects in quick succession there is a race condition where the same records are added to by synced multiple times, this causes a CKError and stops the rest of the batch from completing.

Adding a semaphore here ensures that only one of the `processChanges()` blocks in run at once and therefore ensures that records are converted, processed and removed from history all before running again ensuring no duplicates.